### PR TITLE
Ingress: Update apiVersion to work on Kubernetes 1.22+ (#21166)

### DIFF
--- a/coog/Chart.yaml
+++ b/coog/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "master"
 description: A Helm chart for Coog
 name: coog
-version: 22.18.2218
+version: 22.19.2219-ingress
 icon: http://coopengo.com/img/tn_coog_v2-6_edith.png

--- a/coog/Chart.yaml
+++ b/coog/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "master"
 description: A Helm chart for Coog
 name: coog
-version: 22.19.2219-ingress
+version: 22.20.2220
 icon: http://coopengo.com/img/tn_coog_v2-6_edith.png

--- a/coog/README.md
+++ b/coog/README.md
@@ -1,6 +1,6 @@
 # coog
 
-![Version: 22.17.2217](https://img.shields.io/badge/Version-22.17.2217-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
+![Version: 22.19.2219-ingress](https://img.shields.io/badge/Version-22.19.2219--ingress-informational?style=flat-square) ![AppVersion: master](https://img.shields.io/badge/AppVersion-master-informational?style=flat-square)
 
 A Helm chart for Coog
 
@@ -190,11 +190,18 @@ A Helm chart for Coog
 | coog.workers | int | `2` | Number of coog workers to run |
 | cron.affinity | object | `{}` |  |
 | cron.coogCeleryModule | string | `"coog_async.coog_celery"` |  |
-| cron.enabled | bool | `false` | Deploy cron container(s) |
+| cron.enabled | bool | `true` | Deploy cron container(s) |
+| cron.livenessProbe.failureThreshold | int | `2` |  |
 | cron.livenessProbe.initialDelaySeconds | int | `30` |  |
 | cron.livenessProbe.periodSeconds | int | `120` |  |
+| cron.livenessProbe.successThreshold | int | `1` |  |
 | cron.livenessProbe.timeoutSeconds | int | `10` |  |
 | cron.nodeSelector | object | `{}` | Node labels for pod assignment |
+| cron.readinessProbe.failureThreshold | int | `2` |  |
+| cron.readinessProbe.initialDelaySeconds | int | `30` |  |
+| cron.readinessProbe.periodSeconds | int | `120` |  |
+| cron.readinessProbe.successThreshold | int | `1` |  |
+| cron.readinessProbe.timeoutSeconds | int | `10` |  |
 | cron.resources | object | `{"limits":{"cpu":"200m","memory":"500Mi"},"requests":{"cpu":"100m","memory":"300Mi"}}` | cron containers' resource requests and limits |
 | cron.tolerations | list | `[]` | Tolerations for pod assignment |
 | customer_backend.affinity | object | `{}` | Affinity for pod assignment |

--- a/coog/templates/app-b2c/ingress.yaml
+++ b/coog/templates/app-b2c/ingress.yaml
@@ -29,7 +29,7 @@ spec:
         paths:
         {{- range .paths }}
         - path: {{ . }}
-          pathType: {{ default "Prefix" .pathType }}
+          pathType: Prefix
           backend:
             service:
               name: {{ $fullName }}

--- a/coog/templates/app-b2c/ingress.yaml
+++ b/coog/templates/app-b2c/ingress.yaml
@@ -28,13 +28,13 @@ spec:
       http:
         paths:
         {{- range .paths }}
-          - path: {{ . }}
-            pathType: {{ default "Prefix" .pathType }}
-            backend:
-              service:
-                name: {{ $fullName }}
-                port:
-                  name: http
+        - path: {{ . }}
+          pathType: {{ default "Prefix" .pathType }}
+          backend:
+            service:
+              name: {{ $fullName }}
+              port:
+                name: http
         {{- end }}
   {{- end }}
 {{- end }}

--- a/coog/templates/app-b2c/ingress.yaml
+++ b/coog/templates/app-b2c/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.app_b2c.enabled -}}
 {{- if .Values.app_b2c.ingress.enabled -}}
 {{- $fullName := include "full_name" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -29,9 +29,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: {{ default "Prefix" .pathType }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
         {{- end }}
   {{- end }}
 {{- end }}

--- a/coog/templates/coog/ingress.yaml
+++ b/coog/templates/coog/ingress.yaml
@@ -29,7 +29,7 @@ spec:
         paths:
         {{- range .paths }}
         - path: {{ . }}
-          pathType: {{ default "Prefix" .pathType }}
+          pathType: Prefix
           backend:
             service:
               name: {{ $fullName }}

--- a/coog/templates/coog/ingress.yaml
+++ b/coog/templates/coog/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.coog.enabled -}}
 {{- if .Values.coog.ingress.enabled -}}
 {{- $fullName := include "full_name" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -29,9 +29,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: {{ default "Prefix" .pathType }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
         {{- end }}
   {{- end }}
 {{- end }}

--- a/coog/templates/coog/ingress.yaml
+++ b/coog/templates/coog/ingress.yaml
@@ -28,13 +28,13 @@ spec:
       http:
         paths:
         {{- range .paths }}
-          - path: {{ . }}
-            pathType: {{ default "Prefix" .pathType }}
-            backend:
-              service:
-                name: {{ $fullName }}
-                port:
-                  name: http
+        - path: {{ . }}
+          pathType: {{ default "Prefix" .pathType }}
+          backend:
+            service:
+              name: {{ $fullName }}
+              port:
+                name: http
         {{- end }}
   {{- end }}
 {{- end }}

--- a/coog/templates/customer-backend/ingress.yaml
+++ b/coog/templates/customer-backend/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.customer_backend.enabled -}}
 {{- if .Values.customer_backend.ingress.enabled -}}
 {{- $fullName := include "full_name" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -29,9 +29,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: {{ default "Prefix" .pathType }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
         {{- end }}
   {{- end }}
 {{- end }}

--- a/coog/templates/customer-backend/ingress.yaml
+++ b/coog/templates/customer-backend/ingress.yaml
@@ -29,7 +29,7 @@ spec:
         paths:
         {{- range .paths }}
         - path: {{ . }}
-          pathType: {{ default "Prefix" .pathType }}
+          pathType: Prefix
           backend:
             service:
               name: {{ $fullName }}

--- a/coog/templates/customer-backend/ingress.yaml
+++ b/coog/templates/customer-backend/ingress.yaml
@@ -28,13 +28,13 @@ spec:
       http:
         paths:
         {{- range .paths }}
-          - path: {{ . }}
-            pathType: {{ default "Prefix" .pathType }}
-            backend:
-              service:
-                name: {{ $fullName }}
-                port:
-                  name: http
+        - path: {{ . }}
+          pathType: {{ default "Prefix" .pathType }}
+          backend:
+            service:
+              name: {{ $fullName }}
+              port:
+                name: http
         {{- end }}
   {{- end }}
 {{- end }}

--- a/coog/templates/customer-frontend/ingress.yaml
+++ b/coog/templates/customer-frontend/ingress.yaml
@@ -29,7 +29,7 @@ spec:
         paths:
         {{- range .paths }}
         - path: {{ . }}
-          pathType: {{ default "Prefix" .pathType }}
+          pathType: Prefix
           backend:
             service:
               name: {{ $fullName }}

--- a/coog/templates/customer-frontend/ingress.yaml
+++ b/coog/templates/customer-frontend/ingress.yaml
@@ -28,13 +28,13 @@ spec:
       http:
         paths:
         {{- range .paths }}
-          - path: {{ . }}
-            pathType: {{ default "Prefix" .pathType }}
-            backend:
-              service:
-                name: {{ $fullName }}
-                port:
-                  name: http
+        - path: {{ . }}
+          pathType: {{ default "Prefix" .pathType }}
+          backend:
+            service:
+              name: {{ $fullName }}
+              port:
+                name: http
         {{- end }}
   {{- end }}
 {{- end }}

--- a/coog/templates/customer-frontend/ingress.yaml
+++ b/coog/templates/customer-frontend/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.customer_frontend.enabled -}}
 {{- if .Values.customer_frontend.ingress.enabled -}}
 {{- $fullName := include "full_name" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -29,9 +29,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: {{ default "Prefix" .pathType }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
         {{- end }}
   {{- end }}
 {{- end }}

--- a/coog/templates/gateway/ingress.yaml
+++ b/coog/templates/gateway/ingress.yaml
@@ -29,7 +29,7 @@ spec:
         paths:
         {{- range .paths }}
         - path: {{ . }}
-          pathType: {{ default "Prefix" .pathType }}
+          pathType: Prefix
           backend:
             service:
               name: {{ $fullName }}

--- a/coog/templates/gateway/ingress.yaml
+++ b/coog/templates/gateway/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.gateway.enabled -}}
 {{- if .Values.gateway.ingress.enabled -}}
 {{- $fullName := include "full_name" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -29,9 +29,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: {{ default "Prefix" .pathType }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
         {{- end }}
   {{- end }}
 {{- end }}

--- a/coog/templates/gateway/ingress.yaml
+++ b/coog/templates/gateway/ingress.yaml
@@ -28,13 +28,13 @@ spec:
       http:
         paths:
         {{- range .paths }}
-          - path: {{ . }}
-            pathType: {{ default "Prefix" .pathType }}
-            backend:
-              service:
-                name: {{ $fullName }}
-                port:
-                  name: http
+        - path: {{ . }}
+          pathType: {{ default "Prefix" .pathType }}
+          backend:
+            service:
+              name: {{ $fullName }}
+              port:
+                name: http
         {{- end }}
   {{- end }}
 {{- end }}

--- a/coog/templates/paybox/ingress.yaml
+++ b/coog/templates/paybox/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.paybox.enabled -}}
 {{- if .Values.paybox.ingress.enabled -}}
 {{- $fullName := include "full_name" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -29,9 +29,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: {{ default "Prefix" .pathType }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
         {{- end }}
   {{- end }}
 {{- end }}

--- a/coog/templates/paybox/ingress.yaml
+++ b/coog/templates/paybox/ingress.yaml
@@ -29,7 +29,7 @@ spec:
         paths:
         {{- range .paths }}
         - path: {{ . }}
-          pathType: {{ default "Prefix" .pathType }}
+          pathType: Prefix
           backend:
             service:
               name: {{ $fullName }}

--- a/coog/templates/paybox/ingress.yaml
+++ b/coog/templates/paybox/ingress.yaml
@@ -28,13 +28,13 @@ spec:
       http:
         paths:
         {{- range .paths }}
-          - path: {{ . }}
-            pathType: {{ default "Prefix" .pathType }}
-            backend:
-              service:
-                name: {{ $fullName }}
-                port:
-                  name: http
+        - path: {{ . }}
+          pathType: {{ default "Prefix" .pathType }}
+          backend:
+            service:
+              name: {{ $fullName }}
+              port:
+                name: http
         {{- end }}
   {{- end }}
 {{- end }}

--- a/coog/templates/portal/ingress.yaml
+++ b/coog/templates/portal/ingress.yaml
@@ -29,7 +29,7 @@ spec:
         paths:
         {{- range .paths }}
         - path: {{ . }}
-          pathType: {{ default "Prefix" .pathType }}
+          pathType: Prefix
           backend:
             service:
               name: {{ $fullName }}

--- a/coog/templates/portal/ingress.yaml
+++ b/coog/templates/portal/ingress.yaml
@@ -28,13 +28,13 @@ spec:
       http:
         paths:
         {{- range .paths }}
-          - path: {{ . }}
-            pathType: {{ default "Prefix" .pathType }}
-            backend:
-              service:
-                name: {{ $fullName }}
-                port:
-                  name: http
+        - path: {{ . }}
+          pathType: {{ default "Prefix" .pathType }}
+          backend:
+            service:
+              name: {{ $fullName }}
+              port:
+                name: http
         {{- end }}
   {{- end }}
 {{- end }}

--- a/coog/templates/portal/ingress.yaml
+++ b/coog/templates/portal/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.portal.enabled -}}
 {{- if .Values.portal.ingress.enabled -}}
 {{- $fullName := include "full_name" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -29,9 +29,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: {{ default "Prefix" .pathType }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
         {{- end }}
   {{- end }}
 {{- end }}

--- a/coog/templates/static/ingress.yaml
+++ b/coog/templates/static/ingress.yaml
@@ -29,7 +29,7 @@ spec:
         paths:
         {{- range .paths }}
         - path: {{ . }}
-          pathType: {{ default "Prefix" .pathType }}
+          pathType: Prefix
           backend:
             service:
               name: {{ $fullName }}

--- a/coog/templates/static/ingress.yaml
+++ b/coog/templates/static/ingress.yaml
@@ -28,13 +28,13 @@ spec:
       http:
         paths:
         {{- range .paths }}
-          - path: {{ . }}
-            pathType: {{ default "Prefix" .pathType }}
-            backend:
-              service:
-                name: {{ $fullName }}
-                port:
-                  name: http
+        - path: {{ . }}
+          pathType: {{ default "Prefix" .pathType }}
+          backend:
+            service:
+              name: {{ $fullName }}
+              port:
+                name: http
         {{- end }}
   {{- end }}
 {{- end }}

--- a/coog/templates/static/ingress.yaml
+++ b/coog/templates/static/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.static.enabled -}}
 {{- if .Values.static.ingress.enabled -}}
 {{- $fullName := include "full_name" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -29,9 +29,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: {{ default "Prefix" .pathType }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
         {{- end }}
   {{- end }}
 {{- end }}

--- a/coog/templates/web/ingress.yaml
+++ b/coog/templates/web/ingress.yaml
@@ -29,7 +29,7 @@ spec:
         paths:
         {{- range .paths }}
         - path: {{ . }}
-          pathType: {{ default "Prefix" .pathType }}
+          pathType: Prefix
           backend:
             service:
               name: {{ $fullName }}

--- a/coog/templates/web/ingress.yaml
+++ b/coog/templates/web/ingress.yaml
@@ -28,13 +28,13 @@ spec:
       http:
         paths:
         {{- range .paths }}
-          - path: {{ . }}
-            pathType: {{ default "Prefix" .pathType }}
-            backend:
-              service:
-                name: {{ $fullName }}
-                port:
-                  name: http
+        - path: {{ . }}
+          pathType: {{ default "Prefix" .pathType }}
+          backend:
+            service:
+              name: {{ $fullName }}
+              port:
+                name: http
         {{- end }}
   {{- end }}
 {{- end }}

--- a/coog/templates/web/ingress.yaml
+++ b/coog/templates/web/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.web.enabled -}}
 {{- if .Values.web.ingress.enabled -}}
 {{- $fullName := include "full_name" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -29,9 +29,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: {{ default "Prefix" .pathType }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
         {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Documentation : https://www.civo.com/learn/migrating-your-ingresses-in-k3s-1-20