### PR TITLE
Ptang 31 onboarding mutualisation de rabbit mq recette

### DIFF
--- a/coog/Chart.yaml
+++ b/coog/Chart.yaml
@@ -15,6 +15,7 @@ dependencies:
   - name: rabbitmq
     version: 12.4.2
     repository: https://charts.bitnami.com/bitnami
+    condition: rabbitmq.isManaged
   - name: postgresql
     version: 13.1.5
     repository: https://charts.bitnami.com/bitnami

--- a/coog/templates/secret-backcore.yaml
+++ b/coog/templates/secret-backcore.yaml
@@ -8,8 +8,8 @@ metadata:
 type: Opaque
 stringData:
   TRYTOND_DATABASE__URI: "postgresql://{{ default "" .Values.postgresql.auth.username }}:{{ default "" .Values.postgresql.auth.password }}@{{ default (printf "%s-%s" .Release.Name "postgresql") .Values.postgresql.host }}:{{ default "5432" .Values.postgresql.service.ports.postgresql }}/{{ default .Release.Name .Values.postgresql.auth.database }}"
-  TRYTOND_ASYNC__CELERY: "amqp://{{ .Values.rabbitmq.auth.username }}:{{ .Values.rabbitmq.auth.password }}@{{ .Values.rabbitmq.host | default (printf \"%s-rabbitmq\" .Release.Name) }}:{{ .Values.rabbitmq.service.port | default \"5672\" }}/{{ .Values.rabbitmq.vhost }}"
-  TRYTOND_ASYNC_CELERY: "amqp://{{ .Values.rabbitmq.auth.username }}:{{ .Values.rabbitmq.auth.password }}@{{ .Values.rabbitmq.host | default (printf \"%s-rabbitmq\" .Release.Name) }}:{{ .Values.rabbitmq.service.port | default \"5672\" }}/{{ .Values.rabbitmq.vhost }}"
+  TRYTOND_ASYNC__CELERY: "amqp://{{ .Values.rabbitmq.auth.username }}:{{ .Values.rabbitmq.auth.password }}@{{ .Values.rabbitmq.host | default (printf "%s-rabbitmq" .Release.Name) }}:{{ .Values.rabbitmq.service.port | default "5672" }}{{ if .Values.rabbitmq.vhost }}/{{ .Values.rabbitmq.vhost }}{{ end }}"
+  TRYTOND_ASYNC_CELERY: "amqp://{{ .Values.rabbitmq.auth.username }}:{{ .Values.rabbitmq.auth.password }}@{{ .Values.rabbitmq.host | default (printf "%s-rabbitmq" .Release.Name) }}:{{ .Values.rabbitmq.service.port | default "5672" }}{{ if .Values.rabbitmq.vhost }}/{{ .Values.rabbitmq.vhost }}{{ end }}"
   {{- if not (and .Values.secrets .Values.secrets.backCore .Values.secrets.backCore.extraEnvVar .Values.secrets.backCore.extraEnvVar.TRYTOND_SESSION__PASSPHRASE) }}
   {{ include "secret.token.generator" (dict "key" "TRYTOND_SESSION__PASSPHRASE" "secretName" (printf "%s-backcore-configuration" (include "general.names.short" .)) "namespace" .Release.Namespace) }}
   {{- end }}

--- a/coog/tests/secret-backcore_test.yaml
+++ b/coog/tests/secret-backcore_test.yaml
@@ -115,6 +115,12 @@ tests:
 
   - it: Test variables (3/3)
     set:
+      rabbitmq:
+        isManaged: false
+        auth:
+          username: user1
+          password: password1
+        vhost: vhost
       backCore:
         migrator:
           enabled: true
@@ -131,3 +137,9 @@ tests:
       - equal:
           path: stringData.TRYTOND_MIGRATION__USER
           value: user1
+      - equal:
+          path: stringData.TRYTOND_ASYNC__CELERY
+          value: amqp://user1:password1@test-rabbitmq:5672/vhost
+      - equal:
+          path: stringData.TRYTOND_ASYNC_CELERY
+          value: amqp://user1:password1@test-rabbitmq:5672/vhost

--- a/coog/values.yaml
+++ b/coog/values.yaml
@@ -367,6 +367,7 @@ mongodb:
 # -- Default message service used by backCore
 # Ref: https://artifacthub.io/packages/helm/bitnami/rabbitmq/12.3.0
 rabbitmq:
+  isManaged: true
   persistence:
     enabled: false
   service:


### PR DESCRIPTION
modification de la configuration pour pouvoir surcharger le host et les vhost en fonctions des clients