### PR TITLE
coog-helm-chart: Fix docusign callback ingress

### DIFF
--- a/coog/tests/coog/ingress_test.yaml
+++ b/coog/tests/coog/ingress_test.yaml
@@ -231,3 +231,10 @@ tests:
                       name: test-coog
                       port:
                         number: 80
+                - path: "/docusign"
+                  pathType: ImplementationSpecific
+                  backend:
+                    service:
+                      name: test-coog
+                      port:
+                        number: 80

--- a/coog/values.yaml
+++ b/coog/values.yaml
@@ -544,6 +544,7 @@ backCore:
       # -- Default host for the ingress resource for coog containers'
       defaultPaths:
         - /
+        - /docusign
 
       # -- additionals hosts & paths
       # host : required


### PR DESCRIPTION
backports: 25.14
Fix #PTANG-121

Helm template -f sur les charts:
![image](https://github.com/user-attachments/assets/0b472301-1837-4135-80ad-8d988145a0f1)
